### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,30 @@
+# Documentation Index
+
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/AuditLoggingAPI.md
+- [](&)Documentation/Authentication/README.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/BiometricAuthenticationAPI.md
+- [](&)Documentation/BiometricAuthenticationGuide.md
+- [](&)Documentation/ComplianceGuide.md
+- [](&)Documentation/Encryption/README.md
+- [](&)Documentation/EncryptionAPI.md
+- [](&)Documentation/EncryptionGuide.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/GettingStarted/README.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/KeychainManagementAPI.md
+- [](&)Documentation/Network/README.md
+- [](&)Documentation/NetworkSecurityAPI.md
+- [](&)Documentation/NetworkSecurityGuide.md
+- [](&)Documentation/PerformanceAPI.md
+- [](&)Documentation/PerformanceGuide.md
+- [](&)Documentation/Security/README.md
+- [](&)Documentation/SecurityBestPractices.md
+- [](&)Documentation/SecurityManagerAPI.md
+- [](&)Documentation/Testing/README.md
+- [](&)Documentation/ThreatDetectionAPI.md
+- [](&)Documentation/ThreatDetectionGuide.md
+- [](&)Documentation/Troubleshooting.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,9 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/AdvancedExample.swift
+- ``Examples/AdvancedExamples/AdvancedSecurityExample.swift
+- ``Examples/AdvancedExamples/AdvancedSecurityExamples.swift
+- ``Examples/BasicExample.swift
+- ``Examples/BasicExamples/BasicSecurityExample.swift
+- ``Examples/BasicExamples/BasicSecurityExamples.swift
+- ``Examples/BasicExamples/SecurityExamples.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.